### PR TITLE
split to files

### DIFF
--- a/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js
+++ b/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js
@@ -4,141 +4,8 @@
 'require ui';
 'require dom';
 'require rpc';
+'require view.system.md as md';
 'require view.system.md_help as md_help';
-
-/**
- * Parses a limited subset of Markdown and converts it to HTML.
- *
- * Supported Markdown elements:
- * - Headings (#, ##, ###)
- * - Bold text (**text** or __text__)
- * - Unordered lists (- or *)
- * - Ordered lists (1., 2., etc.)
- * - Paragraphs
- *
- * @param {string} markdown - The Markdown-formatted string.
- * @returns {string} - The resulting HTML string.
- */
-function parseMarkdown(markdown) {
-	// Split the input into lines
-	const lines = markdown.split('\n');
-	const html = [];
-	let inList = false;
-	let listType = ''; // 'ul' or 'ol'
-
-	lines.forEach((line) => {
-		let trimmedLine = line.trim();
-
-		if (trimmedLine === '') {
-			// Empty line signifies a new paragraph
-			if (inList) {
-				html.push(`</${listType}>`);
-				inList = false;
-				listType = '';
-			}
-			return; // Skip adding empty lines to HTML
-		}
-
-		// Check for headings
-		if (/^###\s+(.*)/.test(trimmedLine)) {
-			const content = trimmedLine.replace(/^###\s+/, '');
-			html.push(`<h3>${escapeHtml(content)}</h3>`);
-			return;
-		} else if (/^##\s+(.*)/.test(trimmedLine)) {
-			const content = trimmedLine.replace(/^##\s+/, '');
-			html.push(`<h2>${escapeHtml(content)}</h2>`);
-			return;
-		} else if (/^#\s+(.*)/.test(trimmedLine)) {
-			const content = trimmedLine.replace(/^#\s+/, '');
-			html.push(`<h1>${escapeHtml(content)}</h1>`);
-			return;
-		}
-
-		// Check for ordered lists
-		let orderedMatch = trimmedLine.match(/^(\d+)\.\s+(.*)/);
-		if (orderedMatch) {
-			const [, number, content] = orderedMatch;
-			if (!inList || listType !== 'ol') {
-				if (inList) {
-					html.push(`</${listType}>`);
-				}
-				html.push('<ol>');
-				inList = true;
-				listType = 'ol';
-			}
-			html.push(`<li>${parseInlineMarkdown(escapeHtml(content))}</li>`);
-			return;
-		}
-
-		// Check for unordered lists
-		let unorderedMatch = trimmedLine.match(/^[-*]\s+(.*)/);
-		if (unorderedMatch) {
-			const content = unorderedMatch[1];
-			if (!inList || listType !== 'ul') {
-				if (inList) {
-					html.push(`</${listType}>`);
-				}
-				html.push('<ul>');
-				inList = true;
-				listType = 'ul';
-			}
-			html.push(`<li>${parseInlineMarkdown(escapeHtml(content))}</li>`);
-			return;
-		}
-
-		// If currently inside a list but the line doesn't match a list item, close the list
-		if (inList) {
-			html.push(`</${listType}>`);
-			inList = false;
-			listType = '';
-		}
-
-		// Regular paragraph
-		html.push(`<p>${parseInlineMarkdown(escapeHtml(trimmedLine))}</p>`);
-	});
-
-	// Close any open list tags at the end
-	if (inList) {
-		html.push(`</${listType}>`);
-	}
-
-	return html.join('\n');
-}
-
-/**
- * Parses inline Markdown elements like bold text.
- *
- * Supported inline elements:
- * - Bold text (**text** or __text__)
- *
- * @param {string} text - The text to parse.
- * @returns {string} - The text with inline Markdown converted to HTML.
- */
-function parseInlineMarkdown(text) {
-	// Convert **text** and __text__ to <strong>text</strong>
-	return text
-		.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-		.replace(/__(.+?)__/g, '<strong>$1</strong>');
-}
-
-/**
- * Escapes HTML special characters to prevent XSS attacks.
- *
- * @param {string} text - The text to escape.
- * @returns {string} - The escaped text.
- */
-function escapeHtml(text) {
-	const map = {
-		'&': '&amp;',
-		'<': '&lt;',
-		'>': '&gt;',
-		'"': '&quot;',
-		"'": '&#039;',
-	};
-	return text.replace(/[&<>"']/g, function(m) {
-		return map[m];
-	});
-}
 
 function pop(a, message, severity) {
 	ui.addNotification(a, message, severity)
@@ -2621,7 +2488,7 @@ return view.extend({
 		var self = this;
 
 		// Convert Markdown to HTML
-		var helpContentHTML = parseMarkdown(md_help.helpContentMarkdown);
+		var helpContentHTML = md.parseMarkdown(md_help.helpContentMarkdown);
 
 		// Get the Help content container
 		var helpContent = document.getElementById('content-help');

--- a/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js
+++ b/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js
@@ -1,12 +1,9 @@
-// Enable strict mode for better error checking
 'use strict';
-
-// Require necessary modules from the LuCI framework
-'require view'; // For working with views
-'require fs'; // For filesystem operations
-'require ui'; // For user interface components
-'require dom'; // For DOM manipulation
-'require rpc'; // For remote procedure cajls
+'require view';
+'require fs';
+'require ui';
+'require dom';
+'require rpc';
 
 /**
  * Parses a limited subset of Markdown and converts it to HTML.
@@ -1449,6 +1446,7 @@ var config = {
 		'mtime': 150,
 		'actions': 100
 	},
+
 	// Minimum column widths
 	columnMinWidths: {
 		'name': 100,
@@ -1457,6 +1455,7 @@ var config = {
 		'mtime': 120,
 		'actions': 80
 	},
+
 	// Maximum column widths
 	columnMaxWidths: {
 		'name': 300,
@@ -1465,6 +1464,7 @@ var config = {
 		'mtime': 300,
 		'actions': 200
 	},
+
 	// Padding and window sizes
 	padding: 10,
 	paddingMin: 5,
@@ -1474,6 +1474,7 @@ var config = {
 		width: 800,
 		height: 400
 	},
+
 	editorContainerSizes: {
 		text: {
 			width: 850,
@@ -1484,6 +1485,7 @@ var config = {
 			height: 550
 		}
 	},
+
 	otherSettings: {} // Additional settings
 };
 
@@ -2219,6 +2221,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			return getFileList(currentPath); // Load the file list for the current directory
 		});
 	},
+
 	// Method to render the interface
 	render: function(data) {
 		var self = this;
@@ -2653,6 +2656,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		});
 		return viewContainer;
 	},
+
 	// Handler for the "Select All" checkbox click
 	handleSelectAllClick: function(ev) {
 		if (ev.altKey) {
@@ -2662,6 +2666,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			// Proceed with normal click handling; the 'change' event will be triggered
 		}
 	},
+
 	// Function to invert selection
 	handleInvertSelection: function() {
 		var allCheckboxes = document.querySelectorAll('.select-checkbox');
@@ -2882,6 +2887,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		};
 		fileInput.click();
 	},
+
 	uploadFiles: function(files) {
 		var self = this;
 		var directoryPath = currentPath;
@@ -2943,9 +2949,9 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 				uploadNextFile(index + 1);
 			});
 		}
-
 		uploadNextFile(0);
 	},
+
 	// Handler for creating a directory
 	handleMakeDirectoryClick: function(ev) {
 		// Logic to create a new directory
@@ -2979,6 +2985,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			statusProgress.appendChild(saveButton);
 		}
 	},
+
 	// Function to create a directory
 	createDirectory: function(dirName) {
 		// Execute the 'mkdir' command and update the interface
@@ -3001,6 +3008,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			pop(null, E('p', _('Failed to create directory "%s": %s').format(trimmedDirName, err.message)), 'error');
 		});
 	},
+
 	// Handler for creating a file
 	handleCreateFileClick: function(ev) {
 		// Logic to create a new file
@@ -3034,6 +3042,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			statusProgress.appendChild(createButton);
 		}
 	},
+
 	// Function to create a file
 	createFile: function(fileName) {
 		// Execute the 'touch' command and update the interface
@@ -3056,6 +3065,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			pop(null, E('p', _('Failed to create file "%s": %s').format(trimmedFileName, err.message)), 'error');
 		});
 	},
+
 	// Handler for checkbox state change on a file
 	handleCheckboxChange: function(ev) {
 		// Update the set of selected items
@@ -3069,6 +3079,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		this.updateDeleteSelectedButton();
 		this.updateSelectAllCheckbox();
 	},
+
 	// Update the "Delete Selected" button
 	updateDeleteSelectedButton: function() {
 		// Show or hide the button based on the number of selected items
@@ -3081,6 +3092,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			}
 		}
 	},
+
 	// Update the "Select All" checkbox state
 	updateSelectAllCheckbox: function() {
 		var selectAllCheckbox = document.getElementById('select-all-checkbox');
@@ -3105,6 +3117,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			}
 		}
 	},
+
 	// Handler for the "Select All" checkbox change
 	handleSelectAllChange: function(ev) {
 		// Logic to select or deselect all files
@@ -3121,6 +3134,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		});
 		this.updateDeleteSelectedButton();
 	},
+
 	// Handler for deleting selected items
 	handleDeleteSelected: function() {
 		// Delete selected files and directories
@@ -3148,6 +3162,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			pop(null, E('p', _('Failed to delete selected files and directories: %s').format(err.message)), 'error');
 		});
 	},
+
 	// Function to load the file list
 	loadFileList: function(path) {
 		// Get the list of files and display them in the table
@@ -3337,6 +3352,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			return Promise.reject(err);
 		});
 	},
+
 	// Function to format file size
 	getFormattedSize: function(size) {
 		// Convert the size to a human-readable format (KB, MB, GB)
@@ -3358,6 +3374,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			unit: ' ' + units[unitIndex] + 'B'
 		};
 	},
+
 	// Function to sort files
 	sortBy: function(field) {
 		// Change the sort field and direction, and reload the file list
@@ -3369,6 +3386,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		}
 		this.loadFileList(currentPath);
 	},
+
 	// Function to compare files for sorting
 	compareFiles: function(a, b) {
 		// Compare files based on the selected field and direction
@@ -3383,6 +3401,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		if (aValue > bValue) return 1 * order;
 		return 0;
 	},
+
 	// Set initial column widths in the table
 	setInitialColumnWidths: function() {
 		// Apply column width settings to the file table
@@ -3412,6 +3431,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			}
 		});
 	},
+
 	// Handler for clicking on a directory
 	handleDirectoryClick: function(newPath) {
 		// Navigate to the selected directory and update the file list
@@ -3425,6 +3445,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			self.initResizableColumns();
 		});
 	},
+
 	// Handler for clicking on a file to open it in the editor
 	handleFileClick: function(filePath, mode = 'text') {
 		var self = this;
@@ -3498,7 +3519,6 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		});
 	},
 
-
 	// Adjust padding for line numbers in the editor
 	adjustLineNumbersPadding: function() {
 		// Update padding based on scrollbar size
@@ -3510,6 +3530,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		var scrollbarHeight = editorTextarea.offsetHeight - editorTextarea.clientHeight;
 		lineNumbersDiv.style.paddingBottom = scrollbarHeight + 'px';
 	},
+
 	// Handler for downloading a file
 	handleDownloadFile: function(filePath) {
 		// Download the file to the user's local machine
@@ -3535,6 +3556,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			pop(null, E('p', _('Failed to download file "%s": %s').format(fileName, err.message)), 'error');
 		});
 	},
+
 	// Handler for deleting a file
 	handleDeleteFile: function(filePath, fileInfo) {
 		// Delete the selected file or directory
@@ -3571,6 +3593,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			});
 		}
 	},
+
 	// Update line numbers in the text editor
 	updateLineNumbers: function() {
 		// Update the line numbers display when the text changes
@@ -3587,6 +3610,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		}
 		lineNumbersDiv.innerHTML = lineNumbersContent;
 	},
+
 	// Synchronize scrolling between line numbers and text
 	syncScroll: function() {
 		// Sync scrolling of line numbers with the text area
@@ -3597,6 +3621,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		}
 		lineNumbersDiv.scrollTop = editorTextarea.scrollTop;
 	},
+
 	// Toggle line numbers display in the editor
 	toggleLineNumbers: function() {
 		// Ensure the editor is in Text Mode before toggling line numbers
@@ -3624,6 +3649,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			lineNumbersDiv.innerHTML = '';
 		}
 	},
+
 	// Generate a name for a copy of a file
 	getCopyName: function(originalName, existingNames) {
 		// Create a new unique file name based on the original
@@ -3644,6 +3670,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		}
 		return copyName;
 	},
+
 	// Handler for duplicating a file
 	handleDuplicateFile: function(filePath, fileInfo) {
 		// Copy the file or directory with a new name
@@ -3681,6 +3708,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			pop(null, E('p', _('Failed to get file list: %s').format(err.message)), 'error');
 		});
 	},
+
 	// Handler for saving a file after editing
 	handleSaveFile: function(filePath) {
 		var self = this;
@@ -3814,6 +3842,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			statusInfo.textContent = _('Symlink: ') + linkPath + ' -> ' + targetPath;
 		}
 	},
+
 	// Initialize resizable columns in the table
 	initResizableColumns: function() {
 		// Add handlers to adjust column widths
@@ -3865,6 +3894,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			}
 		});
 	},
+
 	// Handler for editing a file's properties (name, permissions, etc.)
 	handleEditFile: function(filePath, fileInfo) {
 		// Display a form to edit the file's properties
@@ -3919,6 +3949,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			statusProgress.appendChild(saveButton);
 		}
 	},
+
 	// Save changes to a file's properties
 	saveFileChanges: function(filePath, fileInfo, newName, newPerms, newOwner, newGroup) {
 		// Apply changes and update the interface
@@ -3962,7 +3993,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			});
 		});
 		promise.then(function() {
-			pop(null, E('p', _('Changes to %s "%s"uploaded successfully.').format(_('item'), newItemName)), 'info');
+			pop(null, E('p', _('Changes to %s "%s" uploaded successfully.').format(_('item'), newItemName)), 'info');
 			self.loadFileList(currentPath).then(function() {
 				self.initResizableColumns();
 			});
@@ -4092,6 +4123,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 			});
 		}
 	},
+
 	// Load settings into the settings form
 	// Load settings into the settings form
 	loadSettings: function() {
@@ -4341,17 +4373,14 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 				self.fileData = encoder.encode(content);
 			}
 			self.editorMode = 'hex';
-
 		} else {
 			// Before switching to text mode, update self.fileData from the HexEditor
 			if (self.hexEditorInstance) {
 				self.fileData = self.hexEditorInstance.getData();
 			}
-
 			// Convert self.fileData to string
 			var decoder = new TextDecoder();
 			self.fileContent = decoder.decode(self.fileData);
-
 			self.editorMode = 'text';
 		}
 

--- a/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js
+++ b/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js
@@ -4,6 +4,7 @@
 'require ui';
 'require dom';
 'require rpc';
+'require view.system.md_help as md_help';
 
 /**
  * Parses a limited subset of Markdown and converts it to HTML.
@@ -2086,133 +2087,6 @@ tr:hover {
 return view.extend({
 	editorMode: 'text',
 	hexEditorInstance: null,
-	// Define the Help content in Markdown format
-	helpContentMarkdown: `
-# LuCI OpenWrt File Manager Application Help
-
-## Introduction
-The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage files, edit content, and customize the application's settings.
-
-## Key Features
-
-1. **Tabbed Interface**
-   - **File Manager Tab**: Primary interface for browsing and managing files and directories.
-   - **Editor Tab**: Advanced tool for editing file contents in both text and hexadecimal formats.
-   - **Settings Tab**: Customize the application's appearance and behavior according to your preferences.
-   - **Help Tab**: Access detailed instructions and information about the application's features and functionalities.
-
-2. **File Management**
-   - **View Files and Directories**: Display a list of files and folders within the current directory.
-   - **Navigate Directories**: Move into subdirectories or return to parent directories.
-   - **Resizable Columns**: Adjust the width of table columns to enhance readability and organization.
-   - **Drag-and-Drop Uploads**: Upload files by simply dragging them into the designated area.
-   - **Upload via File Selector**: Use the "Upload File" button to select and upload files from your local machine.
-   - **Create New Files and Folders**:
-     - **Create Folder**: Instantiate new directories within the current path.
-     - **Create File**: Generate new empty files for content creation or editing.
-   - **File Actions**:
-     - **Edit**: Modify the contents of files directly within the application.
-     - **Duplicate**: Create copies of existing files or directories.
-     - **Delete**: Remove selected files or directories permanently.
-     - **Download**: Save copies of files to your local machine for offline access.
-
-3. **Selection and Bulk Actions**
-   - **Select All**: Quickly select or deselect all files and directories within the current view using the "Select All" checkbox.
-   - **Invert Selection**: Reverse the current selection of files and directories, selecting previously unselected items and vice versa.
-   - **Individual Selection**: Select or deselect individual files and directories using the checkboxes next to each item.
-   - **Bulk Delete**: Remove multiple selected items simultaneously for efficient management.
-
-4. **Advanced Editing**
-   - **Text Editor**:
-     - **Line Numbers**: Toggle the display of line numbers to assist in content navigation.
-     - **Save Changes**: Commit edits directly to the server.
-   - **Hex Editor**:
-     - **Binary Editing**: Modify file contents at the byte level for advanced users.
-     - **ASCII, HEX and RegExp search**: Search for a pattern in the file and navigate to it.
-     - **Switch Between Modes**: Seamlessly toggle between text and hex editing modes.
-     - **Save Changes**: Apply and save binary modifications.
-
-5. **User Notifications and Status Indicators**
-   - **Progress Bars**: Visual indicators for ongoing operations like file uploads and deletions.
-   - **Notifications**: Informational messages alert users about the success or failure of actions performed.
-
-6. **Customizable Settings**
-   - **Interface Customization**:
-     - **Column Widths**: Define the width of each column in the file list for optimal viewing.
-     - **Window Sizes**: Adjust the size of the file list container and editor windows.
-     - **Padding**: Set padding values to control the spacing within the interface.
-   - **Persistent Configuration**: Save your settings to ensure a consistent user experience across sessions.
-
-## How to Use the Application
-
-1. **Accessing the Application**
-   - Navigate to your OpenWrt device's LuCI web interface.
-   - Locate and select the **File Manager** application from **System** menu .
-
-2. **Navigating the Interface**
-   - **Tabs**: Use the top navigation tabs to switch between **File Manager**, **Editor**, **Settings**, and **Help**.
-   - **File Manager Tab**:
-     - Browse through directories by clicking on folder names.
-     - Use the "Go" button or press "Enter" after typing a path in the path input field to navigate to specific directories.
-   - **Editor Tab**:
-     - Select a file from the File Manager to open it in the Editor.
-     - Choose between text or hex editing modes using the toggle buttons.
-   - **Settings Tab**:
-     - Adjust interface settings such as column widths, window sizes, and padding.
-     - Save your configurations to apply changes immediately.
-   - **Help Tab**:
-     - Access detailed instructions and information about the application's features and functionalities.
-
-3. **Managing Files and Directories**
-   - **Uploading Files**:
-     - **Drag and Drop**: Drag files from your local machine and drop them into the **File List Container** to upload.
-     - **File Selector**: Click the "Upload File" button to open a file dialog and select files for uploading.
-   - **Creating Files/Folders**:
-     - Click on "Create File" or "Create Folder" buttons and provide the necessary names to add new items.
-   - **Editing Files**:
-     - Select a file and click the edit icon (✏️) to modify its contents in the Editor tab.
-   - **Duplicating Files/Folders**:
-     - Use the duplicate icon (📑) to create copies of selected items.
-   - **Deleting Items**:
-     - Select one or multiple items using checkboxes and click the delete icon (🗑️) or use the "Delete Selected" button for bulk deletions.
-   - **Downloading Files**:
-     - Click the download icon (⬇️) next to a file to save it to your local machine.
-
-4. **Using Selection Features**
-   - **Select All**:
-     - Use the "Select All" checkbox located in the table header to select or deselect all files and directories in the current view.
-   - **Invert Selection**:
-     - Hold the "Alt" key and click the "Select All" checkbox to invert the current selection, selecting all unselected items and deselecting previously selected ones.
-   - **Individual Selection**:
-     - Click on the checkbox next to each file or directory to select or deselect it individually.
-
-5. **Using the Editor**
-   - **Text Mode**:
-     - Edit the content of text files with features like line numbers and real-time updates.
-     - Save your changes by clicking the "Save" button.
-   - **Hex Mode**:
-     - Perform binary editing on files for advanced modifications.
-     - Perform ASCII, HEX and RegExp pattern search in the file.
-     - Toggle between text and hex modes as needed.
-     - Save changes to apply your edits.
-     - **Quick Access**: Hold the "Alt" key and click on file names or links to open files directly in the hex editor.
-
-
-6. **Customizing Settings**
-   - Navigate to the **Settings Tab** to personalize the application's layout and behavior.
-   - Adjust parameters such as column widths, window sizes, and padding to suit your preferences.
-   - Save settings to ensure they persist across sessions.
-
-## Additional Functionalities
-
-- **Resizable Columns and Windows**: Enhance the interface's flexibility by resizing table columns and editor windows to match your workflow. The Help window starts at **650x600** pixels and can be adjusted as needed.
-- **Responsive Design**: The application adapts to different screen sizes, ensuring usability across various devices.
-- **Error Handling and Notifications**: Receive immediate feedback on actions, helping you stay informed about the status of your file management tasks.
-- **Line Number Toggle**: Easily show or hide line numbers in the text editor to assist with content navigation.
-- **Bulk Operations**: Efficiently manage multiple files or directories through bulk actions like delete and duplicate.
-- **Symlink Handling**: Navigate and manage symbolic links seamlessly within the file structure.
-
-    `,
 	// Method called when the view is loaded
 	load: function() {
 		var self = this;
@@ -2747,7 +2621,7 @@ The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage file
 		var self = this;
 
 		// Convert Markdown to HTML
-		var helpContentHTML = parseMarkdown(self.helpContentMarkdown);
+		var helpContentHTML = parseMarkdown(md_help.helpContentMarkdown);
 
 		// Get the Help content container
 		var helpContent = document.getElementById('content-help');

--- a/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/md.js
+++ b/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/md.js
@@ -1,0 +1,138 @@
+
+/**
+ * Parses a limited subset of Markdown and converts it to HTML.
+ *
+ * Supported Markdown elements:
+ * - Headings (#, ##, ###)
+ * - Bold text (**text** or __text__)
+ * - Unordered lists (- or *)
+ * - Ordered lists (1., 2., etc.)
+ * - Paragraphs
+ *
+ * @param {string} markdown - The Markdown-formatted string.
+ * @returns {string} - The resulting HTML string.
+ */
+function parseMarkdown(markdown) {
+	// Split the input into lines
+	const lines = markdown.split('\n');
+	const html = [];
+	let inList = false;
+	let listType = ''; // 'ul' or 'ol'
+
+	lines.forEach((line) => {
+		let trimmedLine = line.trim();
+
+		if (trimmedLine === '') {
+			// Empty line signifies a new paragraph
+			if (inList) {
+				html.push(`</${listType}>`);
+				inList = false;
+				listType = '';
+			}
+			return; // Skip adding empty lines to HTML
+		}
+
+		// Check for headings
+		if (/^###\s+(.*)/.test(trimmedLine)) {
+			const content = trimmedLine.replace(/^###\s+/, '');
+			html.push(`<h3>${escapeHtml(content)}</h3>`);
+			return;
+		} else if (/^##\s+(.*)/.test(trimmedLine)) {
+			const content = trimmedLine.replace(/^##\s+/, '');
+			html.push(`<h2>${escapeHtml(content)}</h2>`);
+			return;
+		} else if (/^#\s+(.*)/.test(trimmedLine)) {
+			const content = trimmedLine.replace(/^#\s+/, '');
+			html.push(`<h1>${escapeHtml(content)}</h1>`);
+			return;
+		}
+
+		// Check for ordered lists
+		let orderedMatch = trimmedLine.match(/^(\d+)\.\s+(.*)/);
+		if (orderedMatch) {
+			const [, number, content] = orderedMatch;
+			if (!inList || listType !== 'ol') {
+				if (inList) {
+					html.push(`</${listType}>`);
+				}
+				html.push('<ol>');
+				inList = true;
+				listType = 'ol';
+			}
+			html.push(`<li>${parseInlineMarkdown(escapeHtml(content))}</li>`);
+			return;
+		}
+
+		// Check for unordered lists
+		let unorderedMatch = trimmedLine.match(/^[-*]\s+(.*)/);
+		if (unorderedMatch) {
+			const content = unorderedMatch[1];
+			if (!inList || listType !== 'ul') {
+				if (inList) {
+					html.push(`</${listType}>`);
+				}
+				html.push('<ul>');
+				inList = true;
+				listType = 'ul';
+			}
+			html.push(`<li>${parseInlineMarkdown(escapeHtml(content))}</li>`);
+			return;
+		}
+
+		// If currently inside a list but the line doesn't match a list item, close the list
+		if (inList) {
+			html.push(`</${listType}>`);
+			inList = false;
+			listType = '';
+		}
+
+		// Regular paragraph
+		html.push(`<p>${parseInlineMarkdown(escapeHtml(trimmedLine))}</p>`);
+	});
+
+	// Close any open list tags at the end
+	if (inList) {
+		html.push(`</${listType}>`);
+	}
+
+	return html.join('\n');
+}
+
+/**
+ * Parses inline Markdown elements like bold text.
+ *
+ * Supported inline elements:
+ * - Bold text (**text** or __text__)
+ *
+ * @param {string} text - The text to parse.
+ * @returns {string} - The text with inline Markdown converted to HTML.
+ */
+function parseInlineMarkdown(text) {
+	// Convert **text** and __text__ to <strong>text</strong>
+	return text
+		.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+		.replace(/__(.+?)__/g, '<strong>$1</strong>');
+}
+
+/**
+ * Escapes HTML special characters to prevent XSS attacks.
+ *
+ * @param {string} text - The text to escape.
+ * @returns {string} - The escaped text.
+ */
+function escapeHtml(text) {
+	const map = {
+		'&': '&amp;',
+		'<': '&lt;',
+		'>': '&gt;',
+		'"': '&quot;',
+		"'": '&#039;',
+	};
+	return text.replace(/[&<>"']/g, function(m) {
+		return map[m];
+	});
+}
+
+return L.Class.extend({
+	parseMarkdown: parseMarkdown,
+});

--- a/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/md_help.js
+++ b/applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/md_help.js
@@ -1,0 +1,128 @@
+return L.Class.extend({
+	// Define the Help content in Markdown format
+	helpContentMarkdown: `
+# LuCI OpenWrt File Manager Application Help
+
+## Introduction
+The **LuCI OpenWrt File Manager** is a tool to navigate directories, manage files, edit content, and customize the application's settings.
+
+## Key Features
+
+1. **Tabbed Interface**
+   - **File Manager Tab**: Primary interface for browsing and managing files and directories.
+   - **Editor Tab**: Advanced tool for editing file contents in both text and hexadecimal formats.
+   - **Settings Tab**: Customize the application's appearance and behavior according to your preferences.
+   - **Help Tab**: Access detailed instructions and information about the application's features and functionalities.
+
+2. **File Management**
+   - **View Files and Directories**: Display a list of files and folders within the current directory.
+   - **Navigate Directories**: Move into subdirectories or return to parent directories.
+   - **Resizable Columns**: Adjust the width of table columns to enhance readability and organization.
+   - **Drag-and-Drop Uploads**: Upload files by simply dragging them into the designated area.
+   - **Upload via File Selector**: Use the "Upload File" button to select and upload files from your local machine.
+   - **Create New Files and Folders**:
+     - **Create Folder**: Instantiate new directories within the current path.
+     - **Create File**: Generate new empty files for content creation or editing.
+   - **File Actions**:
+     - **Edit**: Modify the contents of files directly within the application.
+     - **Duplicate**: Create copies of existing files or directories.
+     - **Delete**: Remove selected files or directories permanently.
+     - **Download**: Save copies of files to your local machine for offline access.
+
+3. **Selection and Bulk Actions**
+   - **Select All**: Quickly select or deselect all files and directories within the current view using the "Select All" checkbox.
+   - **Invert Selection**: Reverse the current selection of files and directories, selecting previously unselected items and vice versa.
+   - **Individual Selection**: Select or deselect individual files and directories using the checkboxes next to each item.
+   - **Bulk Delete**: Remove multiple selected items simultaneously for efficient management.
+
+4. **Advanced Editing**
+   - **Text Editor**:
+     - **Line Numbers**: Toggle the display of line numbers to assist in content navigation.
+     - **Save Changes**: Commit edits directly to the server.
+   - **Hex Editor**:
+     - **Binary Editing**: Modify file contents at the byte level for advanced users.
+     - **ASCII, HEX and RegExp search**: Search for a pattern in the file and navigate to it.
+     - **Switch Between Modes**: Seamlessly toggle between text and hex editing modes.
+     - **Save Changes**: Apply and save binary modifications.
+
+5. **User Notifications and Status Indicators**
+   - **Progress Bars**: Visual indicators for ongoing operations like file uploads and deletions.
+   - **Notifications**: Informational messages alert users about the success or failure of actions performed.
+
+6. **Customizable Settings**
+   - **Interface Customization**:
+     - **Column Widths**: Define the width of each column in the file list for optimal viewing.
+     - **Window Sizes**: Adjust the size of the file list container and editor windows.
+     - **Padding**: Set padding values to control the spacing within the interface.
+   - **Persistent Configuration**: Save your settings to ensure a consistent user experience across sessions.
+
+## How to Use the Application
+
+1. **Accessing the Application**
+   - Navigate to your OpenWrt device's LuCI web interface.
+   - Locate and select the **File Manager** application from **System** menu .
+
+2. **Navigating the Interface**
+   - **Tabs**: Use the top navigation tabs to switch between **File Manager**, **Editor**, **Settings**, and **Help**.
+   - **File Manager Tab**:
+     - Browse through directories by clicking on folder names.
+     - Use the "Go" button or press "Enter" after typing a path in the path input field to navigate to specific directories.
+   - **Editor Tab**:
+     - Select a file from the File Manager to open it in the Editor.
+     - Choose between text or hex editing modes using the toggle buttons.
+   - **Settings Tab**:
+     - Adjust interface settings such as column widths, window sizes, and padding.
+     - Save your configurations to apply changes immediately.
+   - **Help Tab**:
+     - Access detailed instructions and information about the application's features and functionalities.
+
+3. **Managing Files and Directories**
+   - **Uploading Files**:
+     - **Drag and Drop**: Drag files from your local machine and drop them into the **File List Container** to upload.
+     - **File Selector**: Click the "Upload File" button to open a file dialog and select files for uploading.
+   - **Creating Files/Folders**:
+     - Click on "Create File" or "Create Folder" buttons and provide the necessary names to add new items.
+   - **Editing Files**:
+     - Select a file and click the edit icon (✏️) to modify its contents in the Editor tab.
+   - **Duplicating Files/Folders**:
+     - Use the duplicate icon (📑) to create copies of selected items.
+   - **Deleting Items**:
+     - Select one or multiple items using checkboxes and click the delete icon (🗑️) or use the "Delete Selected" button for bulk deletions.
+   - **Downloading Files**:
+     - Click the download icon (⬇️) next to a file to save it to your local machine.
+
+4. **Using Selection Features**
+   - **Select All**:
+     - Use the "Select All" checkbox located in the table header to select or deselect all files and directories in the current view.
+   - **Invert Selection**:
+     - Hold the "Alt" key and click the "Select All" checkbox to invert the current selection, selecting all unselected items and deselecting previously selected ones.
+   - **Individual Selection**:
+     - Click on the checkbox next to each file or directory to select or deselect it individually.
+
+5. **Using the Editor**
+   - **Text Mode**:
+     - Edit the content of text files with features like line numbers and real-time updates.
+     - Save your changes by clicking the "Save" button.
+   - **Hex Mode**:
+     - Perform binary editing on files for advanced modifications.
+     - Perform ASCII, HEX and RegExp pattern search in the file.
+     - Toggle between text and hex modes as needed.
+     - Save changes to apply your edits.
+     - **Quick Access**: Hold the "Alt" key and click on file names or links to open files directly in the hex editor.
+
+
+6. **Customizing Settings**
+   - Navigate to the **Settings Tab** to personalize the application's layout and behavior.
+   - Adjust parameters such as column widths, window sizes, and padding to suit your preferences.
+   - Save settings to ensure they persist across sessions.
+
+## Additional Functionalities
+
+- **Resizable Columns and Windows**: Enhance the interface's flexibility by resizing table columns and editor windows to match your workflow. The Help window starts at **650x600** pixels and can be adjusted as needed.
+- **Responsive Design**: The application adapts to different screen sizes, ensuring usability across various devices.
+- **Error Handling and Notifications**: Receive immediate feedback on actions, helping you stay informed about the status of your file management tasks.
+- **Line Number Toggle**: Easily show or hide line numbers in the text editor to assist with content navigation.
+- **Bulk Operations**: Efficiently manage multiple files or directories through bulk actions like delete and duplicate.
+- **Symlink Handling**: Navigate and manage symbolic links seamlessly within the file structure.
+`
+});


### PR DESCRIPTION
Я докинул пример как разделить на разные файлы.

В целом больше чем 4000 строк это чёт многовато. Не только для роутера но и для понимания. А это всё ещё потом поддерживать. С одной стороны я понимаю что хочеться сделать чтобы было пользователям удобно, но тут всё же нужно срезать углы и делать по рабоче-крестьянски чтобы любой смог разобраться и переделать если нужно.

Например, я бы полностью выкинул все опции. Вот зачем нужна опция чтобы показывать или скрывать номера строк? Да всегда показывайте если уже сделали, чего уж.
Всякие другие опции тоже в топку, эстеты потерпят. Нормальные люди вообще один раз в жизни видят админку когда настраивают роутер и на этом всё.

Вот тот же рендер маркдауна используется.... только в помощи по его же синтаксису. Кому нужна эта помощь? Можно на крайний случай в интернете почитать. Что вообще маркдаун файлы забыли на роутере?
Вот что можно и даже бывает нужно так это подсветить синтаксис шел скрипта или конфига. Но это очень редко нужно, по факту тебе бывает нужно просто в нескольких местах подправить пару строк и ничего кроме моноширинного текста не нужно. 

Я понимаю что вам (или чатжпг?) не тяжело, но другим это всё вычитывать, тестировать и чинить когда вы уйдёте в закат.
 